### PR TITLE
Clean up run_all_pro imports

### DIFF
--- a/scripts/run_all_pro.py
+++ b/scripts/run_all_pro.py
@@ -2,16 +2,8 @@
 # Ejecutar en VS Code con ▶️  (sin Jupyter). Requiere: pandas, numpy, matplotlib, mplsoccer, jinja2
 
 
-# Auto-instalar si falta (opcional)
-import sys, subprocess, importlib, argparse
-for pkg in ["pandas", "numpy", "matplotlib", "mplsoccer", "jinja2"]:
-    try:
-        importlib.import_module(pkg)
-    except Exception:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "--user", pkg])
-
-=======
-
+# Dependencias
+import argparse
 from pathlib import Path
 import pandas as pd, numpy as np, math
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary
- Remove merge marker and runtime package installation from `run_all_pro.py`
- Simplify dependency imports to rely on requirements file

## Testing
- `pytest -q`
- `python scripts/run_all_pro.py --events data/events.csv --matches data/matches.csv --output test_output`

------
https://chatgpt.com/codex/tasks/task_e_68abae1242c883298bc0daa5b8417936