### PR TITLE
Validate required columns before processing match data

### DIFF
--- a/scripts/run_all_pro.py
+++ b/scripts/run_all_pro.py
@@ -310,12 +310,19 @@ def process_match(
 
     teams = [meta.get('home_team', 'Equipo A'), meta.get('away_team', 'Equipo B')]
 
+    required_cols = {
+        'match_id', 'team', 'is_shot', 'is_goal', 'is_pass', 'is_def_action',
+        'x', 'y', 'end_x', 'end_y', 'xg', 'minute'
+    }
+    missing = required_cols - set(events.columns)
+    if missing:
+        missing_str = ', '.join(sorted(missing))
+        raise ValueError(f"Missing required column(s): {missing_str}")
+
     for c in ['is_shot', 'is_goal', 'is_pass', 'is_def_action']:
-        if c in events.columns:
-            events[c] = pd.to_numeric(events[c], errors='coerce').fillna(0).astype(int)
+        events[c] = pd.to_numeric(events[c], errors='coerce').fillna(0).astype(int)
     for c in ['x', 'y', 'end_x', 'end_y', 'xg', 'minute']:
-        if c in events.columns:
-            events[c] = pd.to_numeric(events[c], errors='coerce')
+        events[c] = pd.to_numeric(events[c], errors='coerce')
 
     shots = events[events.get('is_shot', 0) == 1].copy()
     if 'xg' not in shots.columns or shots['xg'].isna().all():

--- a/tests/test_process_match.py
+++ b/tests/test_process_match.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from run_all_pro import process_match
+
+
+def test_process_match_missing_required_column(tmp_path):
+    events = pd.DataFrame([
+        {
+            "match_id": 1,
+            # "team" column intentionally omitted to trigger error
+            "is_shot": 1,
+            "is_goal": 0,
+            "x": 100,
+            "y": 40,
+            "xg": 0.1,
+            "minute": 10,
+            "is_pass": 0,
+            "is_def_action": 0,
+            "end_x": None,
+            "end_y": None,
+        }
+    ])
+
+    meta = {
+        "home_team": "Home",
+        "away_team": "Away",
+        "home_goals": 0,
+        "away_goals": 0,
+        "date": "2023-01-01",
+    }
+
+    brand_path = Path(__file__).resolve().parents[1] / "brand"
+
+    with pytest.raises(ValueError, match="team"):
+        process_match(events, meta, tmp_path, brand_path)
+


### PR DESCRIPTION
## Summary
- enforce presence of core event columns in `process_match`
- raise a descriptive `ValueError` when a required column is missing
- add regression test for missing column handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb5bad6608329b6c600fa94f21b53