### PR TITLE
Ensure HTML report uses relative asset paths

### DIFF
--- a/scripts/ush_report.py
+++ b/scripts/ush_report.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, Sequence, Any
 from jinja2 import Environment, FileSystemLoader
 import pandas as pd
+import os
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
 
@@ -37,15 +38,21 @@ def render_html_report_pro(meta: Dict[str, Any],
     title = f"{teams[1]} @ {teams[0]} — Ida {meta['competition']} ({meta['date']}, {meta['venue_city']})"
     env = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
     template = env.get_template("ush_report_pro.html")
+
+    base = out_path.parent
+
+    def _rel(p: Path) -> str:
+        return os.path.relpath(p, start=base)
+
     html = template.render(
         title=title,
-        logo=str(logo_path),
+        logo=_rel(logo_path),
         comp=meta["competition"], date=meta["date"], venue=meta["venue_city"],
         home=teams[0], away=teams[1],
         home_goals=meta.get("home_goals", ""), away_goals=meta.get("away_goals", ""),
         teams=teams, kpis=kpis, ppda=ppda_vals, team_focus=teams[1],
-        shotmap=str(shotmap_path), xgrace=str(xgrace_path),
-        passnet=str(passnet_path), pressure=str(pressure_path),
+        shotmap=_rel(shotmap_path), xgrace=_rel(xgrace_path),
+        passnet=_rel(passnet_path), pressure=_rel(pressure_path),
         year=pd.Timestamp.now().year
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import os
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -175,3 +176,48 @@ def test_render_html_report_pro_creates_files(tmp_path):
     assert passnet_path.exists()
     assert pressure_path.exists()
     assert html_path.exists()
+
+
+def test_render_html_report_pro_relative_paths(tmp_path):
+    meta = {
+        "competition": "Friendly",
+        "date": "2023-01-01",
+        "venue_city": "City",
+        "home_goals": 0,
+        "away_goals": 0,
+    }
+    teams = ["Home", "Away"]
+    kpis = {t: {"shots": 0, "goals": 0, "xg": 0.0, "xt": 0.0} for t in teams}
+    ppda_vals = {t: None for t in teams}
+
+    shotmap_path = tmp_path / "shotmap.png"
+    xgrace_path = tmp_path / "xg_race.png"
+    passnet_path = tmp_path / "pass_network.png"
+    pressure_path = tmp_path / "pressure.png"
+    for p in [shotmap_path, xgrace_path, passnet_path, pressure_path]:
+        p.write_text("img")
+
+    logo_path = Path(__file__).resolve().parents[1] / "brand" / "ush_logo_dark.svg"
+    html_path = tmp_path / "report.html"
+
+    render_html_report_pro(
+        meta,
+        teams,
+        kpis,
+        ppda_vals,
+        shotmap_path,
+        xgrace_path,
+        passnet_path,
+        pressure_path,
+        logo_path,
+        html_path,
+    )
+
+    html = html_path.read_text()
+    base = html_path.parent
+
+    assert f'src="{os.path.relpath(shotmap_path, base)}"' in html
+    assert f'src="{os.path.relpath(xgrace_path, base)}"' in html
+    assert f'src="{os.path.relpath(passnet_path, base)}"' in html
+    assert f'src="{os.path.relpath(pressure_path, base)}"' in html
+    assert f'src="{os.path.relpath(logo_path, base)}"' in html


### PR DESCRIPTION
## Summary
- Resolve logo and visual asset paths relative to the report output directory to produce portable HTML links
- Add regression test to confirm generated report uses relative paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb6b10d888329a20248121efd90c4