### PR TITLE
Handle missing receivers in passing network

### DIFF
--- a/tests/test_draw_functions.py
+++ b/tests/test_draw_functions.py
@@ -62,6 +62,35 @@ def _sample_events():
     ])
 
 
+def _sample_events_missing_receiver():
+    return pd.DataFrame([
+        {
+            'team': 'Away',
+            'is_pass': 1,
+            'event_type': 'Pass',
+            'player': 'A1',
+            'receiver': None,
+            'x': 50,
+            'y': 40,
+            'end_x': 80,
+            'end_y': 50,
+            'minute': 5,
+        },
+        {
+            'team': 'Away',
+            'is_pass': 1,
+            'event_type': 'Pass',
+            'player': 'A1',
+            'receiver': '',
+            'x': 55,
+            'y': 45,
+            'end_x': 85,
+            'end_y': 55,
+            'minute': 15,
+        },
+    ])
+
+
 def _meta():
     return {'home_goals': 0, 'away_goals': 1, 'date': '2023-01-01'}
 
@@ -104,6 +133,18 @@ def test_draw_pass_network_pro_creates_image(tmp_path):
     meta = _meta()
     kpis = _kpis()
     out = tmp_path / 'passnet.png'
+    draw_pass_network_pro(events, teams, meta, kpis, 'Away', out)
+    assert out.exists()
+    assert _not_empty(out)
+
+
+def test_draw_pass_network_pro_handles_missing_receivers(tmp_path):
+    set_ush_theme()
+    events = _sample_events_missing_receiver()
+    teams = ['Home', 'Away']
+    meta = _meta()
+    kpis = _kpis()
+    out = tmp_path / 'passnet_missing.png'
     draw_pass_network_pro(events, teams, meta, kpis, 'Away', out)
     assert out.exists()
     assert _not_empty(out)


### PR DESCRIPTION
## Summary
- Move `GridSpec` import to module header in `run_all_pro.py`
- Filter out passes missing `receiver` before computing passing network and document requirement
- Add regression test for datasets without receivers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb811ee488329b2f00fdc6a31a396