### PR TITLE
Load Inter font in report template

### DIFF
--- a/templates/ush_report_pro.html
+++ b/templates/ush_report_pro.html
@@ -1,5 +1,6 @@
 <!doctype html><html lang='es'><head><meta charset='utf-8'>
 <meta name='viewport' content='width=device-width,initial-scale=1'><title>{{ title }}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 <style>
 :root{
   --navy:#0A2540;--cyan:#00C2FF;--blue:#5B86E5;--paper:#FFFFFF;--fog:#E6EEF6;


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts in report template

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbb23af248329a0a89b7295624ea9