### PR TITLE
refactor: move inline styles into css classes

### DIFF
--- a/report/river_libertad_report.html
+++ b/report/river_libertad_report.html
@@ -5,7 +5,8 @@
 *{box-sizing:border-box} body{font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#F6FAFF;color:var(--ink)}
 .wrap{max-width:980px;margin:0 auto;padding:16px}
 .card{background:var(--paper);border-radius:16px;box-shadow:0 6px 24px rgba(10,37,64,.08);padding:20px;margin:16px 0}
-h1{margin:0;font-size:32px} h2{margin-top:0}
+h1{margin:0;font-size:32px}
+.section-title{margin-top:0}
 .kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
 .kpi{background:#EEF4FF;border-radius:12px;padding:12px}
 .kpi b{font-size:16px}
@@ -19,6 +20,10 @@ footer{font-size:12px;color:#567;text-align:center;padding:24px}
 .cover h1{font-size:40px}
 .tag{display:inline-block;background:var(--cyan);color:#001018;padding:6px 10px;border-radius:999px;font-weight:600;margin-left:8px}
 .meta{margin-top:12px;color:#cfe3ff}
+.logo{height:72px}
+.figure-title{margin:4px 0 8px 0}
+.full-span{grid-column:1/-1}
+.goal{color:var(--goal)}
 hr.sep{border:none;border-top:2px solid var(--fog);margin:8px 0}
 @media print{@page{size:A4;margin:12mm} .pagebreak{page-break-before:always} a[href]:after{content:''}}
 </style></head>
@@ -26,7 +31,7 @@ hr.sep{border:none;border-top:2px solid var(--fog);margin:8px 0}
   <section class="cover">
     <div class="wrap">
       <div class="title">
-        <img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\brand\ush_logo_dark.svg" alt="Ush Analytics" style="height:72px">
+        <img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\brand\ush_logo_dark.svg" alt="Ush Analytics" class="logo">
         <div>
           <h1>Informe pospartido <span class="tag">Ush Analytics</span></h1>
           <div>CONMEBOL Libertadores — 2025-08-14 — Asunción</div>
@@ -41,7 +46,7 @@ hr.sep{border:none;border-top:2px solid var(--fog);margin:8px 0}
 
   <div class="wrap pagebreak">
     <section class="card">
-      <h2>KPIs</h2>
+      <h2 class="section-title">KPIs</h2>
       <div class="kpis">
         
         <div class="kpi">
@@ -64,21 +69,21 @@ hr.sep{border:none;border-top:2px solid var(--fog);margin:8px 0}
     </section>
 
     <section class="card">
-      <h2>Visuales</h2>
+      <h2 class="section-title">Visuales</h2>
       <div class="grid">
-        <div><h3>Shot Map</h3><img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\report\img\shotmap.png" alt="Shot Map"></div>
-        <div><h3>xG acumulado</h3><img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\report\img\xg_race.png" alt="xG acumulado"></div>
-        <div style="grid-column:1/-1">
-          <h3>Red de pases — River Plate</h3>
+        <div><h3 class="figure-title">Shot Map</h3><img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\report\img\shotmap.png" alt="Shot Map"></div>
+        <div><h3 class="figure-title">xG acumulado</h3><img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\report\img\xg_race.png" alt="xG acumulado"></div>
+        <div class="full-span">
+          <h3 class="figure-title">Red de pases — River Plate</h3>
           <img src="C:\Users\Usuario\Desktop\river_libertad_portfolio_pack_branded\report\img\pass_network.png" alt="Red de pases">
         </div>
       </div>
     </section>
 
     <section class="card">
-      <h2>Notas rápidas</h2>
+      <h2 class="section-title">Notas rápidas</h2>
       <ul>
-        <li><b>Momentum:</b> River mejoró su xG en el ST y marcó en momentos clave <span style="color:var(--goal)">(2)</span>.</li>
+        <li><b>Momentum:</b> River mejoró su xG en el ST y marcó en momentos clave <span class="goal">(2)</span>.</li>
         <li><b>Construcción:</b> Libertad priorizó mitad de cancha; pressing selectivo de River (PPDA más bajo).</li>
         <li><b>Circulación:</b> Foco en carril derecho para River Plate con conexiones fuertes interior–extremo.</li>
       </ul>

--- a/templates/ush_report_pro.html
+++ b/templates/ush_report_pro.html
@@ -10,7 +10,8 @@
 .wrap{max-width:1000px;margin:0 auto;padding:16px}
 .card{background:rgba(10,37,64,.25);backdrop-filter:blur(6px);border:1px solid rgba(230,238,246,.08);
       border-radius:16px;box-shadow:0 6px 24px rgba(10,37,64,.28);padding:20px;margin:16px 0}
-h1{margin:0;font-size:32px} h2{margin:0 0 10px 0}
+h1{margin:0;font-size:32px}
+.section-title{margin:0 0 10px 0}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
 .kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
 .kpi{background:rgba(230,238,246,.06);border:1px solid rgba(230,238,246,.10);border-radius:12px;padding:12px}
@@ -22,8 +23,13 @@ footer{font-size:12px;color:#BFD0E6;text-align:center;padding:24px}
 .cover h1{font-size:40px;margin:0}
 .badge{display:inline-flex;align-items:center;gap:10px;background:var(--cyan);color:#001018;border-radius:999px;
        padding:6px 12px;font-weight:700;margin-left:10px}
-.meta{margin-top:10px;color:#cfe3ff}
+.meta{margin-top:14px;color:#cfe3ff}
 .small{font-size:12px;color:#BFD0E6}
+.logo{height:72px}
+.note{margin-top:6px}
+.figure-title{margin:4px 0 8px 0}
+.figure-title-top{margin-top:8px}
+.full-span{grid-column:1/-1}
 @media print{@page{size:A4;margin:12mm} .pagebreak{page-break-before:always} a[href]:after{content:''}}
 </style></head>
 <body>
@@ -32,13 +38,13 @@ footer{font-size:12px;color:#BFD0E6;text-align:center;padding:24px}
   <section class="cover">
     <div class="wrap">
       <div class="title">
-        <img src="{{ logo }}" alt="Ush Analytics" style="height:72px">
+        <img src="{{ logo }}" alt="Ush Analytics" class="logo">
         <div>
           <h1>Informe pospartido <span class="badge">Ush Analytics</span></h1>
           <div>{{ comp }} — {{ date }} — {{ venue }}</div>
         </div>
       </div>
-      <div class="meta" style="margin-top:14px">
+      <div class="meta">
         <div><b>Partido:</b> {{ away }} @ {{ home }} — Ida</div>
         <div><b>Marcador:</b> {{ away_goals }}–{{ home_goals }}</div>
       </div>
@@ -48,7 +54,7 @@ footer{font-size:12px;color:#BFD0E6;text-align:center;padding:24px}
   <!-- CONTENIDO -->
   <div class="wrap pagebreak">
     <section class="card">
-      <h2>KPIs</h2>
+      <h2 class="section-title">KPIs</h2>
       <div class="kpis">
         {% for t in teams %}
         <div class="kpi">
@@ -61,33 +67,33 @@ footer{font-size:12px;color:#BFD0E6;text-align:center;padding:24px}
         </div>
         {% endfor %}
       </div>
-      <div class="small" style="margin-top:6px">PPDA: pases rivales permitidos por acciones defensivas propias en zona alta. Menor = más presión.</div>
+      <div class="small note">PPDA: pases rivales permitidos por acciones defensivas propias en zona alta. Menor = más presión.</div>
     </section>
 
     <section class="card">
-      <h2>Visuales</h2>
+      <h2 class="section-title">Visuales</h2>
       <div class="grid">
         <div>
-          <h3 style="margin:4px 0 8px 0">Shot Map</h3>
+          <h3 class="figure-title">Shot Map</h3>
           <img src="{{ shotmap }}" alt="Shot Map">
         </div>
         <div>
-          <h3 style="margin:4px 0 8px 0">xG acumulado</h3>
+          <h3 class="figure-title">xG acumulado</h3>
           <img src="{{ xgrace }}" alt="xG Race">
         </div>
         <div>
-          <h3 style="margin:4px 0 8px 0">Mapa de presión</h3>
+          <h3 class="figure-title">Mapa de presión</h3>
           <img src="{{ pressure }}" alt="Pressure Map">
         </div>
-        <div style="grid-column:1/-1">
-          <h3 style="margin:8px 0 8px 0">Red de pases — {{ team_focus }}</h3>
+        <div class="full-span">
+          <h3 class="figure-title figure-title-top">Red de pases — {{ team_focus }}</h3>
           <img src="{{ passnet }}" alt="Passing Network">
         </div>
       </div>
     </section>
 
     <section class="card">
-      <h2>Notas rápidas</h2>
+      <h2 class="section-title">Notas rápidas</h2>
       <ul>
         <li><b>Momentum:</b> {{ away }} mejoró su xG en el ST y convirtió en momentos clave.</li>
         <li><b>Construcción:</b> {{ home }} priorizó el juego en mitad; presión selectiva del rival (PPDA más bajo).</li>


### PR DESCRIPTION
## Summary
- define reusable CSS classes like `.logo`, `.section-title`, `.figure-title` and more
- replace inline `style="..."` attributes in HTML templates with these classes
- ensure no redundant inline styles remain

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbc38f2c08329b5ee02f4a49d23ea