### PR TITLE
feat: add Ush Pro Matplotlib style

### DIFF
--- a/styles/ush_pro.mplstyle
+++ b/styles/ush_pro.mplstyle
@@ -5,4 +5,9 @@ axes.labelcolor  : #E6EEF6
 xtick.color      : #E6EEF6
 ytick.color      : #E6EEF6
 text.color       : #E6EEF6
+lines.solid_capstyle : round
+legend.facecolor : none
+legend.edgecolor : none
+savefig.dpi      : 240
+axes.prop_cycle  : cycler('color', ['#5B86E5', '#00C2FF', '#FF3366'])
 font.family      : sans-serif


### PR DESCRIPTION
## Summary
- add ush_pro.mplstyle with palette colors, DPI, legend and line defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acdba204b8832994f0c79aac361c9e