### PR TITLE
feat(metrics): add goalkeeper metrics

### DIFF
--- a/scripts/metrics_goalkeepers.py
+++ b/scripts/metrics_goalkeepers.py
@@ -1,0 +1,120 @@
+"""Goalkeeping metrics for football event data.
+
+This module provides basic goalkeeping metrics calculated from event streams.
+Functions operate on DataFrames containing at minimum the columns
+``shot_psxg``, ``shot_outcome``, ``under_pressure``, ``pass_length`` and
+``goalkeeper``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def psxg_minus_ga(events: pd.DataFrame) -> pd.DataFrame:
+    """Post-shot xG minus goals allowed for each goalkeeper.
+
+    Parameters
+    ----------
+    events:
+        Event stream with ``shot_psxg``, ``shot_outcome`` and ``goalkeeper``
+        columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``goalkeeper`` and ``psxg_minus_ga`` columns.
+    """
+    shots = events.dropna(subset=["shot_psxg"]).copy()
+    if shots.empty:
+        return pd.DataFrame(columns=["goalkeeper", "psxg_minus_ga"])
+
+    if shots["shot_outcome"].dtype.kind in "biufc":
+        shots["goals"] = shots["shot_outcome"].astype(float)
+    else:
+        shots["goals"] = shots["shot_outcome"].str.lower().eq("goal").astype(int)
+
+    agg = shots.groupby("goalkeeper").agg(psxg=("shot_psxg", "sum"), goals=("goals", "sum"))
+    agg["psxg_minus_ga"] = agg["psxg"] - agg["goals"]
+    return agg[["psxg_minus_ga"]].reset_index()
+
+
+def shot_stopping_pct(events: pd.DataFrame) -> pd.DataFrame:
+    """Shot-stopping percentage based on post-shot xG.
+
+    Calculated as ``(PSxG - goals) / PSxG`` for each goalkeeper.
+
+    Parameters
+    ----------
+    events:
+        Event stream with ``shot_psxg``, ``shot_outcome`` and ``goalkeeper``
+        columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``goalkeeper`` and ``shot_stopping_pct`` columns.
+    """
+    shots = events.dropna(subset=["shot_psxg"]).copy()
+    if shots.empty:
+        return pd.DataFrame(columns=["goalkeeper", "shot_stopping_pct"])
+
+    if shots["shot_outcome"].dtype.kind in "biufc":
+        shots["goals"] = shots["shot_outcome"].astype(float)
+    else:
+        shots["goals"] = shots["shot_outcome"].str.lower().eq("goal").astype(int)
+
+    agg = shots.groupby("goalkeeper").agg(psxg=("shot_psxg", "sum"), goals=("goals", "sum"))
+    agg["shot_stopping_pct"] = (agg["psxg"] - agg["goals"]) / agg["psxg"].replace(0, np.nan)
+    return agg[["shot_stopping_pct"]].reset_index()
+
+
+def cross_claims(events: pd.DataFrame) -> pd.DataFrame:
+    """Count cross claims for each goalkeeper.
+
+    The function treats rows where ``under_pressure`` equals one as cross
+    claim actions.
+    """
+    keepers = events[["goalkeeper"]].drop_duplicates()
+    claims = (
+        events[events.get("under_pressure", 0) == 1]
+        .groupby("goalkeeper")
+        .size()
+        .rename("cross_claims")
+    )
+    out = keepers.merge(claims, on="goalkeeper", how="left").fillna({"cross_claims": 0})
+    return out
+
+
+def sweeper_actions(events: pd.DataFrame, threshold: float = 30.0) -> pd.DataFrame:
+    """Count long passes by goalkeepers as a proxy for sweeper actions.
+
+    Parameters
+    ----------
+    events:
+        Event stream with ``pass_length`` and ``goalkeeper`` columns.
+    threshold:
+        Minimum ``pass_length`` for an action to be considered a sweeper
+        action.  Defaults to 30 metres.
+    """
+    keepers = events[["goalkeeper"]].drop_duplicates()
+    cond = events.get("pass_length", 0) >= threshold
+    agg = events[cond].groupby("goalkeeper").size().rename("sweeper_actions")
+    out = keepers.merge(agg, on="goalkeeper", how="left").fillna({"sweeper_actions": 0})
+    return out
+
+
+def distribution_under_pressure(events: pd.DataFrame) -> pd.DataFrame:
+    """Average pass length when under pressure for each goalkeeper."""
+    cond = events.get("under_pressure", 0) == 1
+    agg = (
+        events[cond]
+        .groupby("goalkeeper")["pass_length"]
+        .mean()
+        .rename("distribution_under_pressure")
+    )
+    keepers = events[["goalkeeper"]].drop_duplicates()
+    out = keepers.merge(agg, on="goalkeeper", how="left").fillna(
+        {"distribution_under_pressure": 0}
+    )
+    return out

--- a/tests/test_metrics_goalkeepers.py
+++ b/tests/test_metrics_goalkeepers.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from metrics_goalkeepers import (
+    psxg_minus_ga,
+    shot_stopping_pct,
+    cross_claims,
+    sweeper_actions,
+    distribution_under_pressure,
+)
+
+
+def synthetic_goalkeeper_events():
+    """Return a tiny goalkeeper dataset for testing."""
+    return pd.DataFrame(
+        [
+            {"goalkeeper": "A", "shot_psxg": 0.8, "shot_outcome": "Goal", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "A", "shot_psxg": 0.3, "shot_outcome": "Saved", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "A", "shot_psxg": 0.2, "shot_outcome": "Goal", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "A", "shot_psxg": None, "shot_outcome": None, "under_pressure": 1, "pass_length": 25},
+            {"goalkeeper": "A", "shot_psxg": None, "shot_outcome": None, "under_pressure": 1, "pass_length": 5},
+            {"goalkeeper": "A", "shot_psxg": None, "shot_outcome": None, "under_pressure": 0, "pass_length": 30},
+            {"goalkeeper": "B", "shot_psxg": 0.1, "shot_outcome": "Saved", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "B", "shot_psxg": 0.4, "shot_outcome": "Goal", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "B", "shot_psxg": 0.5, "shot_outcome": "Saved", "under_pressure": 0, "pass_length": None},
+            {"goalkeeper": "B", "shot_psxg": None, "shot_outcome": None, "under_pressure": 1, "pass_length": 40},
+            {"goalkeeper": "B", "shot_psxg": None, "shot_outcome": None, "under_pressure": 1, "pass_length": 50},
+            {"goalkeeper": "B", "shot_psxg": None, "shot_outcome": None, "under_pressure": 0, "pass_length": 10},
+        ]
+    )
+
+
+def test_goalkeeper_metrics():
+    events = synthetic_goalkeeper_events()
+
+    psxg_df = psxg_minus_ga(events)
+    assert pytest.approx(psxg_df.loc[psxg_df.goalkeeper == "A", "psxg_minus_ga"].iloc[0], 1e-6) == pytest.approx(-0.7, 1e-6)
+    assert pytest.approx(psxg_df.loc[psxg_df.goalkeeper == "B", "psxg_minus_ga"].iloc[0], 1e-6) == pytest.approx(0.0, 1e-6)
+
+    stop_df = shot_stopping_pct(events)
+    assert pytest.approx(stop_df.loc[stop_df.goalkeeper == "A", "shot_stopping_pct"].iloc[0], 1e-6) == pytest.approx(-0.5384615, 1e-6)
+    assert stop_df.loc[stop_df.goalkeeper == "B", "shot_stopping_pct"].iloc[0] == 0
+
+    claims_df = cross_claims(events)
+    assert claims_df.loc[claims_df.goalkeeper == "A", "cross_claims"].iloc[0] == 2
+    assert claims_df.loc[claims_df.goalkeeper == "B", "cross_claims"].iloc[0] == 2
+
+    sweep_df = sweeper_actions(events)
+    assert sweep_df.loc[sweep_df.goalkeeper == "A", "sweeper_actions"].iloc[0] == 1
+    assert sweep_df.loc[sweep_df.goalkeeper == "B", "sweeper_actions"].iloc[0] == 2
+
+    dist_df = distribution_under_pressure(events)
+    assert dist_df.loc[dist_df.goalkeeper == "A", "distribution_under_pressure"].iloc[0] == pytest.approx(15)
+    assert dist_df.loc[dist_df.goalkeeper == "B", "distribution_under_pressure"].iloc[0] == pytest.approx(45)


### PR DESCRIPTION
## Summary
- add metrics for goalkeeper shot stopping and distribution
- validate new metrics with synthetic tests

## Testing
- `pytest tests/test_metrics_goalkeepers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace9489af883299514896cb918e2ce