### PR TITLE
feat(metrics): classify phases as build-up, progression and finalization

### DIFF
--- a/tests/test_metrics_context.py
+++ b/tests/test_metrics_context.py
@@ -18,12 +18,12 @@ def sample_events():
     """Return a small dataset for context metric tests."""
     return pd.DataFrame(
         [
-            {"team": "A", "period": 1, "minute": 1, "is_goal": 0, "in_possession": 1, "is_set_piece": 0, "xg": 0.1},
-            {"team": "B", "period": 1, "minute": 2, "is_goal": 1, "in_possession": 1, "is_set_piece": 0, "xg": 0.2},
-            {"team": "A", "period": 1, "minute": 3, "is_goal": 0, "in_possession": 1, "is_set_piece": 1, "xg": 0.05},
-            {"team": "B", "period": 1, "minute": 4, "is_goal": 0, "in_possession": 0, "is_set_piece": 0, "xg": 0.0},
-            {"team": "A", "period": 2, "minute": 5, "is_goal": 1, "in_possession": 1, "is_set_piece": 0, "xg": 0.3},
-            {"team": "B", "period": 2, "minute": 6, "is_goal": 0, "in_possession": 1, "is_set_piece": 0, "xg": 0.1},
+            {"team": "A", "period": 1, "minute": 1, "is_goal": 0, "x": 10, "y": 50, "event_type": "pass", "xg": 0.1},
+            {"team": "B", "period": 1, "minute": 2, "is_goal": 1, "x": 90, "y": 50, "event_type": "shot", "xg": 0.2},
+            {"team": "A", "period": 1, "minute": 3, "is_goal": 0, "x": 50, "y": 40, "event_type": "pass", "xg": 0.05},
+            {"team": "B", "period": 1, "minute": 4, "is_goal": 0, "x": 20, "y": 30, "event_type": "pass", "xg": 0.0},
+            {"team": "A", "period": 2, "minute": 5, "is_goal": 1, "x": 95, "y": 60, "event_type": "shot", "xg": 0.3},
+            {"team": "B", "period": 2, "minute": 6, "is_goal": 0, "x": 60, "y": 50, "event_type": "pass", "xg": 0.1},
         ]
     )
 
@@ -43,12 +43,12 @@ def test_state_and_phase_classification():
 
     with_phase = phase_of_play(events)
     assert list(with_phase["phase"]) == [
-        "attack",
-        "attack",
-        "set_piece",
-        "defence",
-        "attack",
-        "attack",
+        "build_up",
+        "finalization",
+        "progression",
+        "build_up",
+        "finalization",
+        "progression",
     ]
 
 
@@ -62,14 +62,14 @@ def test_context_aggregations():
     assert pytest.approx(b_level, 1e-6) == pytest.approx(0.3, 1e-6)
 
     agg_phase = aggregate_by_phase(events, ["xg"])
-    a_attack = agg_phase.loc[(agg_phase.team == "A") & (agg_phase.phase == "attack"), "xg"].iloc[0]
-    b_def = agg_phase.loc[(agg_phase.team == "B") & (agg_phase.phase == "defence"), "xg"].iloc[0]
-    assert pytest.approx(a_attack, 1e-6) == pytest.approx(0.4, 1e-6)
-    assert b_def == 0.0
+    a_final = agg_phase.loc[(agg_phase.team == "A") & (agg_phase.phase == "finalization"), "xg"].iloc[0]
+    b_build = agg_phase.loc[(agg_phase.team == "B") & (agg_phase.phase == "build_up"), "xg"].iloc[0]
+    assert pytest.approx(a_final, 1e-6) == pytest.approx(0.3, 1e-6)
+    assert b_build == 0.0
 
     agg_all = aggregate_context(events, ["xg"])
     row = agg_all.loc[
-        (agg_all.team == "A") & (agg_all.period == 1) & (agg_all.score_state == "behind") & (agg_all.phase == "set_piece"),
+        (agg_all.team == "A") & (agg_all.period == 1) & (agg_all.score_state == "behind") & (agg_all.phase == "progression"),
         "xg",
     ].iloc[0]
     assert pytest.approx(row, 1e-6) == pytest.approx(0.05, 1e-6)

--- a/tests/test_phase_of_play.py
+++ b/tests/test_phase_of_play.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from metrics_context import phase_of_play
+
+
+def test_phase_assignment():
+    df = pd.DataFrame(
+        [
+            {"x": 10, "y": 50, "event_type": "pass"},
+            {"x": 60, "y": 40, "event_type": "pass"},
+            {"x": 85, "y": 60, "event_type": "pass"},
+            {"x": 30, "y": 70, "event_type": "shot"},
+        ]
+    )
+    phases = phase_of_play(df)["phase"].tolist()
+    assert phases == [
+        "build_up",
+        "progression",
+        "finalization",
+        "finalization",
+    ]


### PR DESCRIPTION
## Summary
- expand `phase_of_play` to derive build_up, progression and finalization using x/y position and event type
- update aggregators to work with new phase labels
- add dedicated tests for phase classification and update context aggregation tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf5440e44832984e351fa13a8b33c