### PR TITLE
style(styles): tighten colon spacing in ush_pro style

### DIFF
--- a/styles/ush_pro.mplstyle
+++ b/styles/ush_pro.mplstyle
@@ -1,13 +1,13 @@
-figure.facecolor : #0A2540
-axes.facecolor   : #0A2540
-axes.edgecolor   : #E6EEF6
-axes.labelcolor  : #E6EEF6
-xtick.color      : #E6EEF6
-ytick.color      : #E6EEF6
-text.color       : #E6EEF6
-lines.solid_capstyle : round
-legend.facecolor : none
-legend.edgecolor : none
-savefig.dpi      : 240
-axes.prop_cycle  : cycler('color', ['#5B86E5', '#00C2FF', '#FF3366'])
-font.family      : sans-serif
+figure.facecolor: #0A2540
+axes.facecolor: #0A2540
+axes.edgecolor: #E6EEF6
+axes.labelcolor: #E6EEF6
+xtick.color: #E6EEF6
+ytick.color: #E6EEF6
+text.color: #E6EEF6
+lines.solid_capstyle: round
+legend.facecolor: none
+legend.edgecolor: none
+savefig.dpi: 240
+axes.prop_cycle: cycler(color=['#5B86E5', '#00C2FF', '#FF3366'])
+font.family: sans-serif


### PR DESCRIPTION
## Summary
- remove spaces around colons in Ush Pro mplstyle
- specify color cycle via `cycler(color=[...])`

## Testing
- `python scripts/run_all_pro.py --events data/events.csv --matches data/matches.csv --output out_dir` *(fails: Key figure.facecolor: '' does not look like a color arg; Missing required column(s): is_def_action, is_pass, team)*

------
https://chatgpt.com/codex/tasks/task_e_68acf9dd88948329b9cfe1cecde64b93