### PR TITLE
feat: add run_demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ El archivo `report/img/pass_network.png` se crea al ejecutar el comando anterior
 
 El informe HTML utiliza un template Jinja ubicado en `templates/ush_report_pro.html`. Si editás ese archivo, los cambios se reflejarán automáticamente al volver a ejecutar el pipeline.
 
+### Ejemplo rápido
+
+Si querés un vistazo rápido con datos sintéticos:
+
+```
+python scripts/run_demo.py
+```
+
 ## Jupyter
 Abrí `notebooks/01_river_libertad_pospartido.ipynb` y ejecutá todo.
 

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -1,0 +1,7 @@
+"""Ejecuta la pipeline pro con datos sintéticos para un ejemplo rápido."""
+
+from run_all_pro import main
+
+
+if __name__ == "__main__":
+    main(demo=True)


### PR DESCRIPTION
## Summary
- add run_demo script for quick demo
- document run_demo in README as fast example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acfe9631b08329a290b925d527f217