### PR TITLE
fix(gui): map team names when loading matches

### DIFF
--- a/scripts/run_gui.py
+++ b/scripts/run_gui.py
@@ -81,6 +81,9 @@ def main():
         if not path:
             return
         matches_df = pd.read_csv(path)
+        teams = pd.read_csv(data_dir / "teams.csv").set_index("team_id")["name"]
+        matches_df["home_team"] = matches_df["home_team_id"].map(teams)
+        matches_df["away_team"] = matches_df["away_team_id"].map(teams)
         match_map.clear()
         options = []
         for _, row in matches_df.iterrows():


### PR DESCRIPTION
## Summary
- map team ids to team names when populating match selector

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad02bed53c8329a055c74fe85c885a