### PR TITLE
feat(gui): show selected file names

### DIFF
--- a/scripts/run_gui.py
+++ b/scripts/run_gui.py
@@ -73,7 +73,7 @@ def main():
         )
         if path:
             events_path.set(path)
-            events_btn.config(text="Cambiar...")
+            events_btn.config(text=f"Eventos: {Path(path).name}")
 
     def load_matches(path: str):
         """Load matches from CSV and populate dropdown."""
@@ -94,7 +94,7 @@ def main():
             match_var.set(options[0])
             match_cb["values"] = options
             match_cb.current(0)
-        matches_btn.config(text="Cambiar...")
+        matches_btn.config(text=f"Partidos: {Path(path).name}")
 
     def select_matches():
         """Pick matches CSV, read it and populate dropdown."""
@@ -151,10 +151,10 @@ def main():
             root.update_idletasks()
 
     # --- layout ---
-    events_btn = ttk.Button(root, text="Cambiar...", command=select_events)
+    events_btn = ttk.Button(root, text="Eventos", command=select_events)
     events_btn.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
 
-    matches_btn = ttk.Button(root, text="Cambiar...", command=select_matches)
+    matches_btn = ttk.Button(root, text="Partidos", command=select_matches)
     matches_btn.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
 
     match_cb = ttk.Combobox(root, textvariable=match_var, state="readonly", width=40)


### PR DESCRIPTION
## Summary
- display chosen events and matches filenames on GUI buttons
- label buttons as `Eventos` and `Partidos` by default for clarity

## Testing
- `python -m py_compile scripts/run_gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad09a9f3508329b7908a61417a52a6