### PR TITLE
fix: stabilize pro report pipeline

### DIFF
--- a/styles/ush_pro.mplstyle
+++ b/styles/ush_pro.mplstyle
@@ -1,13 +1,13 @@
-figure.facecolor: #0A2540
-axes.facecolor: #0A2540
-axes.edgecolor: #E6EEF6
-axes.labelcolor: #E6EEF6
-xtick.color: #E6EEF6
-ytick.color: #E6EEF6
-text.color: #E6EEF6
-lines.solid_capstyle: round
-legend.facecolor: none
-legend.edgecolor: none
-savefig.dpi: 240
-axes.prop_cycle: cycler(color=['#5B86E5', '#00C2FF', '#FF3366'])
-font.family: sans-serif
+figure.facecolor : "#0A2540"
+axes.facecolor   : "#0A2540"
+axes.edgecolor   : "#E6EEF6"
+axes.labelcolor  : "#E6EEF6"
+xtick.color      : "#E6EEF6"
+ytick.color      : "#E6EEF6"
+text.color       : "#E6EEF6"
+lines.solid_capstyle : round
+legend.facecolor : none
+legend.edgecolor : none
+savefig.dpi      : 240
+axes.prop_cycle  : cycler('color', ["#5B86E5", "#00C2FF", "#FF3366"])
+font.family      : sans-serif


### PR DESCRIPTION
## Summary
- infer pass receivers and player names when loading event data
- map team IDs to names for matches
- fix mpl style hex colors and color cycle

## Testing
- `pytest`
- `python scripts/run_all_pro.py --events data/events.csv --matches data/matches.csv --output .`


------
https://chatgpt.com/codex/tasks/task_e_68ad0fa5a14883299b1f7a5f6f4f5b67