### PR TITLE
style(styles): refine Ush Pro mpl theme

### DIFF
--- a/styles/ush_pro.mplstyle
+++ b/styles/ush_pro.mplstyle
@@ -1,13 +1,47 @@
-figure.facecolor : "#0A2540"
-axes.facecolor   : "#0A2540"
-axes.edgecolor   : "#E6EEF6"
-axes.labelcolor  : "#E6EEF6"
-xtick.color      : "#E6EEF6"
-ytick.color      : "#E6EEF6"
-text.color       : "#E6EEF6"
-lines.solid_capstyle : round
-legend.facecolor : none
-legend.edgecolor : none
-savefig.dpi      : 240
-axes.prop_cycle  : cycler('color', ["#5B86E5", "#00C2FF", "#FF3366"])
-font.family      : sans-serif
+# Ush Analytics Pro Matplotlib style
+
+# Brand color variables
+# --ush-navy:  #0A2540
+# --ush-cyan:  #00C2FF
+# --ush-pink:  #FF3366
+# --ush-gray:  #E6EEF6
+
+figure.facecolor      : "#0A2540"
+axes.facecolor        : "#0A2540"
+axes.edgecolor        : "#E6EEF6"
+axes.labelcolor       : "#E6EEF6"
+xtick.color           : "#E6EEF6"
+ytick.color           : "#E6EEF6"
+text.color            : "#E6EEF6"
+
+# Typography
+font.family           : Rajdhani, Inter, system-ui, Segoe UI
+font.weight           : regular
+font.style            : normal
+axes.titleweight      : bold
+
+font.size             : 12
+axes.titlesize        : 16
+xtick.labelsize       : 10
+ytick.labelsize       : 10
+legend.fontsize       : 11
+
+# Lines and legend
+lines.solid_capstyle  : round
+legend.facecolor      : none
+legend.edgecolor      : none
+
+# Layout and grid
+axes.grid             : False
+figure.figsize        : 16, 10
+figure.autolayout     : True
+figure.dpi            : 240
+
+# Savefig settings
+savefig.dpi           : 240
+savefig.bbox          : "tight"
+savefig.pad_inches    : 0
+
+# Color cycle mapping brand colors
+# Cycle order: ush-cyan, ush-pink, ush-gray
+axes.prop_cycle       : cycler('color', ["#00C2FF", "#FF3366", "#E6EEF6"])


### PR DESCRIPTION
## Summary
- Align Ush Pro theme with brand fonts and color cycle
- Set default figure size, layout, and high-DPI export settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad1452c17c8329ac9c0ed874def092