### PR TITLE
feat(viz): improve shot map layering and goal labels

### DIFF
--- a/scripts/ush_style.py
+++ b/scripts/ush_style.py
@@ -265,7 +265,8 @@ def shot_marker_kwargs(on_target: bool, color: str) -> dict:
         Keyword arguments suitable for ``Axes.scatter``.
     """
     marker = "s" if on_target else "o"
-    alpha = 0.95 if on_target else 0.7
+    # Shots on target should stand out more via opacity and edge width
+    alpha = 0.9 if on_target else 0.4
     lw = 1.0 if on_target else 0.8
     return {
         "marker": marker,
@@ -331,15 +332,39 @@ def annotate_goals_scatter(ax, shots_df, marker_size: float = 200,
     if goals.empty:
         return
     goal_color = color or COLORS["goal"]
-    ax.scatter(goals["x"], goals["y"], s=marker_size, marker="*",
-               color=goal_color, edgecolors="white", linewidths=1.0,
-               zorder=5)
+    ax.scatter(
+        goals["x"],
+        goals["y"],
+        s=marker_size,
+        marker="*",
+        color=goal_color,
+        edgecolors="white",
+        linewidths=1.2,
+        zorder=3,
+    )
+    labels = []
     for _, row in goals.iterrows():
         minute = row.get("minute")
+        player = row.get("player")
+        parts = []
         if minute is not None and not np.isnan(minute):
-            ax.text(row["x"], row["y"] - 2, f"{int(minute)}'",
-                    ha="center", va="top", fontsize=8,
-                    color="white", zorder=6)
+            parts.append(f"{int(minute)}'")
+        if player and isinstance(player, str):
+            parts.append(player)
+        if parts:
+            lbl = text_halo(
+                ax,
+                " ".join(parts),
+                x=row["x"],
+                y=row["y"] - 2,
+                ha="center",
+                va="top",
+                fontsize=8,
+                color=COLORS["ink"],
+                zorder=4,
+            )
+            labels.append(lbl)
+    avoid_overlap(labels)
 
 
 def annotate_goals_on_xg(ax, shots_df, team: str,

--- a/tests/test_draw_functions.py
+++ b/tests/test_draw_functions.py
@@ -21,6 +21,7 @@ def _sample_shots():
             'y': 40,
             'xg': 0.1,
             'minute': 10,
+            'player': 'Home Shooter',
         },
         {
             'team': 'Away',
@@ -30,6 +31,7 @@ def _sample_shots():
             'y': 30,
             'xg': 0.2,
             'minute': 20,
+            'player': 'Away Scorer',
         },
     ])
 
@@ -112,6 +114,17 @@ def test_draw_shot_map_pro_creates_image(tmp_path):
     meta = _meta()
     out = tmp_path / 'shotmap.png'
     draw_shot_map_pro(shots, teams, meta, out)
+    assert out.exists()
+    assert _not_empty(out)
+
+
+def test_draw_shot_map_pro_without_title(tmp_path):
+    plt.style.use("styles/ush_pro.mplstyle")
+    shots = _sample_shots()
+    teams = ['Home', 'Away']
+    meta = _meta()
+    out = tmp_path / 'shotmap_notitle.png'
+    draw_shot_map_pro(shots, teams, meta, out, show_title=False)
     assert out.exists()
     assert _not_empty(out)
 


### PR DESCRIPTION
## Summary
- Refine shot marker scaling and opacity; clamp sizes to 40–520 and vary alpha by result
- Annotate goals with haloed minute/player labels and ensure proper z-order layering
- Move legend outside pitch, hide axes, add optional title toggle for shot map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad17de8d1c832985fb3d9c25afa926